### PR TITLE
fix throw; alpha release

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1241,7 +1241,7 @@
                                   |r $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1535652004344) (:text |response) (:id |oX3xMmc5KUE)
                               |r $ {} (:type :expr) (:by |-OxUkFUX3) (:at 1535652004344) (:id |nzChvX3qoku)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1535652004344) (:text |js/throw) (:id |fYrw2lvC2W6)
+                                  |T $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1578379806306) (:text |throw) (:id |fYrw2lvC2W6)
                                   |j $ {} (:type :expr) (:by |-OxUkFUX3) (:at 1535652004344) (:id |6nILhX4qZda)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1535652004344) (:text |js/Error.) (:id |CcXr0JivzJp)

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "mvc-works",
        :artifact-id "skir",
-       :version "0.0.4",
+       :version "0.0.5-a1",
        :name "An over-simplified Node.js HTTP server"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/skir/core.cljs
+++ b/src/skir/core.cljs
@@ -37,8 +37,7 @@
       (fn? response) (response (fn [response-data] (write-response! res response-data)))
       (promise? response) (.then response (fn [result] (write-response! res result)))
       (chan? response) (go (write-response! res (<! response)) (close! response))
-      :else
-        (do (println "Response:" response) (js/throw (js/Error. "Unrecognized response!"))))))
+      :else (do (println "Response:" response) (throw (js/Error. "Unrecognized response!"))))))
 
 (defn create-server!
   ([handler] (create-server! handler nil))


### PR DESCRIPTION
`js/throw` generates shim file like:

```js
/** @const {ShadowJS} */ var Promise;
/** @const {ShadowJS} */ var throw;
ShadowJS.prototype.NEGATIVE_INFINITY;
ShadowJS.prototype.NaN;
```

where `var throw` has a problem that would break compilation.
