### PR TITLE
fix js hint; alpha release

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1291,6 +1291,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1534218329959) (:text |res) (:id |RYcphEq34)
                   |j $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1534218334239) (:text |edn-res) (:id |CxbWxuR_-u)
+                  |D $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1578474112576) (:text |^js) (:id |bQ-186qVK)
               |v $ {} (:type :expr) (:by |-OxUkFUX3) (:at 1534218357978) (:id |ZOq-Gw_MI)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |-OxUkFUX3) (:at 1534218367794) (:text |set!) (:id |3s_PQ8dzi)

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "mvc-works",
        :artifact-id "skir",
-       :version "0.0.5-a1",
+       :version "0.0.5-a2",
        :name "An over-simplified Node.js HTTP server"}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/skir/core.cljs
+++ b/src/skir/core.cljs
@@ -16,7 +16,7 @@
    :headers (js->clj (.-headers req) :keywordize-keys true),
    :body nil})
 
-(defn write-response! [res edn-res]
+(defn write-response! [^js res edn-res]
   (set! (.-statusCode res) (:code edn-res))
   (set! (.-statusMessage res) (:message edn-res))
   (doseq [[k v] (:headers edn-res)] (.setHeader res (key->str k) (key->str v)))


### PR DESCRIPTION
Old code breaks in Closure advanced compilation. Shadow-cljs need `^js` to telling out js objects.
